### PR TITLE
Remove underline and strikethrough in rich text

### DIFF
--- a/public/js/quill.js
+++ b/public/js/quill.js
@@ -4,7 +4,9 @@ var quill = new Quill("#editor", {
   modules: {
     toolbar: [
       // [{ size: ["small", false, "large", "huge"] }],
-      ["bold", "italic", "underline", "strike"],
+      ["bold", "italic"], //, "underline", "strike"],
+      // In slack, prof hill said "Strong and Em are fine to use", but we can not use <u> and <s> so we commented them out
+      // https://stevenswebdevs2023.slack.com/archives/C04GT4VC2CW/p1683320626601129?thread_ts=1683320245.987919&cid=C04GT4VC2CW
       ["image"],
       [{ list: "bullet" }],
       ["clean"],


### PR DESCRIPTION
Removed underline and strikethrough options.
Prof Hill said we can use `<strong>` and `<em>`, but not `<s>` and `<u>`.
"Strong and Em are fine to use"

![image](https://user-images.githubusercontent.com/7242589/236586578-91cffc23-4d3f-46fd-a7ef-4cc835e7d511.png)

![image](https://user-images.githubusercontent.com/7242589/236586593-a67f0a22-53b5-4199-9cc4-f0f551a0f341.png)
